### PR TITLE
Add syntactic sugar for evidence

### DIFF
--- a/src/Problox.jl
+++ b/src/Problox.jl
@@ -62,6 +62,7 @@ export SimpleProgram, Var, Constant, AnnotatedDisjunction, term
 
 # Convenience.
 query = term("query")
-export query, evaluate, variable
+evidence = term("evidence")
+export query, evidence, evaluate, variable
 
 end # module


### PR DESCRIPTION
Up to you whether to accept - I could see this being a slippery slope, but it's nice for autocomplete since `evidence` is a pretty critical atom/predicate for ProbLog.